### PR TITLE
Migrate to AWS_ENDPOINT_URL

### DIFF
--- a/create-user.py
+++ b/create-user.py
@@ -9,6 +9,7 @@ localstackHost = "http://localhost:4566"
 client = boto3.client('rds', endpoint_url=localstackHost)
 sm = boto3.client('secretsmanager', endpoint_url=localstackHost)
 
+
 def db_ops():
     secret_arn = sm.list_secrets()["SecretList"][0]["ARN"]
     secret = sm.get_secret_value(SecretId=secret_arn)

--- a/rds/app.py
+++ b/rds/app.py
@@ -1,13 +1,18 @@
-import json
 import boto3
+import json
 from os import environ
+from urllib.parse import urlparse
 
 import psycopg2
 
 
-localstackHost = f"http://{environ.get('LOCALSTACK_HOSTNAME')}:{environ.get('EDGE_PORT')}"
-client = boto3.client('rds', endpoint_url=localstackHost)
-sm = boto3.client('secretsmanager', endpoint_url=localstackHost)
+endpoint_url = environ.get("AWS_ENDPOINT_URL")
+url = urlparse(endpoint_url)
+host = url.hostname
+
+client = boto3.client('rds', endpoint_url=endpoint_url)
+sm = boto3.client('secretsmanager', endpoint_url=endpoint_url)
+
 
 def db_ops():
     secret_arn = sm.list_secrets()["SecretList"][0]["ARN"]
@@ -18,7 +23,7 @@ def db_ops():
     try:
         # create a connection object
         connection = psycopg2.connect(
-            host=environ.get('LOCALSTACK_HOSTNAME'),
+            host=host,
             database="mylab",
             user=username,
             password=password,
@@ -41,4 +46,3 @@ def lambda_handler(event, context):
         'statusCode': 200,
         'body': json.dumps(results, default=str)
     }
-    

--- a/rdsproxy/app.py
+++ b/rdsproxy/app.py
@@ -1,18 +1,22 @@
 import json
 import boto3
 from os import environ
+from urllib.parse import urlparse
 
 import psycopg2
 
-localstackHost = f"http://{environ.get('LOCALSTACK_HOSTNAME')}:{environ.get('EDGE_PORT')}"
-client = boto3.client('rds', endpoint_url=localstackHost)  # get the rds object
+
+endpoint_url = environ.get("AWS_ENDPOINT_URL")
+url = urlparse(endpoint_url)
+hostname = url.hostname
+
+client = boto3.client('rds', endpoint_url=endpoint_url)  # get the rds object
 
 
 def create_proxy_connection_token(username):
     # get the required parameters to create a token
-    region = environ.get('region')  # get the region
-    hostname = environ.get('LOCALSTACK_HOSTNAME')  # get the rds proxy endpoint
-    port = 4510 # get the database port
+    region = environ.get('region')
+    port = 4510 # database port
 
     # generate the authentication token -- temporary password
     token = client.generate_db_auth_token(
@@ -33,7 +37,7 @@ def db_ops():
     try:
         # create a connection object
         connection = psycopg2.connect(
-            host=environ.get('LOCALSTACK_HOSTNAME'),
+            host=hostname,
             database="mylab",
             user=username,
             password=token,


### PR DESCRIPTION
Adopt `AWS_ENDPOINT_URL` as the official endpoint variable introduced by AWS.

See https://docs.localstack.cloud/user-guide/tools/transparent-endpoint-injection/

/cc repo maintainer @sannya-singal

## Suggested Follow-up

Why do we adopt the application code for LocalStack rather than injecting the configuration through IaC like in the original AWS example?
https://github.com/aws-samples/serverless-rds-proxy-demo/blob/main/template.yaml#L85-L89

IMHO, It would be better to adopt clean IaC practices and separate code from configuration. Then we don't need to rely on LocalStack-only environment variables.